### PR TITLE
Add distributed tracing for media service

### DIFF
--- a/media-service/build.gradle
+++ b/media-service/build.gradle
@@ -35,6 +35,10 @@ dependencies {
 	implementation 'org.springframework.cloud:spring-cloud-starter-config'
 	implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'
 	implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'
+	// for tracing
+	implementation 'org.springframework.cloud:spring-cloud-starter-sleuth'
+	implementation 'org.springframework.cloud:spring-cloud-sleuth-brave'
+	implementation 'org.springframework.cloud:spring-cloud-sleuth-zipkin'
 	// for logging (compatible for java 8)
 	implementation 'org.slf4j:slf4j-api:1.7.30'
 	implementation 'org.slf4j:jcl-over-slf4j:1.7.30'

--- a/media-service/src/main/resources/application.properties
+++ b/media-service/src/main/resources/application.properties
@@ -3,6 +3,9 @@ spring.application.name=media-service
 spring.config.import=optional:configserver:http://localhost:8084
 eureka.client.serviceUrl.defaultZone=http://localhost:8761/eureka
 
+# tracing settings
+spring.sleuth.sampler.probability=1.0
+
 spring.datasource.url = jdbc:postgresql://localhost:5432/elearning
 spring.datasource.username = postgres
 spring.datasource.password = postgres


### PR DESCRIPTION
- Downloaded Zipklin server on my local system
- Managed to setup distributed tracing on media-service.
- Added dependencies in build.gradle
- Configured a setting in application.properties to ensure that every request passing through the system will be traced